### PR TITLE
Allow running on Node.js < 10

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 const assert = require('assert');
-const { types } = require('util');
+const types = require('util').types || {
+  // approximate polyfill for Node.js < 10
+  isExternal(x: any): boolean {
+    return Object.prototype.toString.call(x) === '[object Object]';
+  }
+};
 
 const native = require('node-gyp-build')(__dirname + '/..');
 


### PR DESCRIPTION
Most functions currently fail to run on Node.js versions earlier than 10, because `isHKEY()` uses `util.types.isExternal()`, which was only added in v10.0.0. This commit adds a stub replacement. It is less discriminating than it should be (I haven’t found a more precise way), but since it is only used for argument type checking, that should be good enough. Tested on v8.16.2.