### PR TITLE
Fix intermittent closing of unrelated handles after closeKey

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,4 @@
 const assert = require('assert');
-const types = require('util').types || {
-  // approximate polyfill for Node.js < 10
-  isExternal(x: any): boolean {
-    return Object.prototype.toString.call(x) === '[object Object]';
-  }
-};
 
 const native = require('node-gyp-build')(__dirname + '/..');
 
@@ -101,7 +95,7 @@ export const HKU = HKEY.USERS;
 export type Value = Buffer & { type: ValueType };
 
 export function isHKEY(hkey: any): hkey is HKEY {
-  return types.isExternal(hkey) || hkey && hkey === (hkey >>> 0); // checks value is a uint32
+  return Object.prototype.toString.call(hkey) === '[object HKEY]' || hkey && hkey === (hkey >>> 0); // checks value is a uint32
 }
 
 // Raw APIs


### PR DESCRIPTION
Me again with another bug! :)

**Symptom**: When running code that opens and closes registry keys on the interactive Node.js REPL in a Windows command prompt, it would occasionally stop accepting keyboard input. Killing the node.exe process would return the window to a working state and process the backlogged keystrokes on the command prompt.

**Cause**: A JavaScript registry key handle that was explicitly closed using `reg.closeKey()` was later closed again by the finalizer when garbage-collected. Most of the time the second `RegCloseKey()` call would fail silently, but occasionally it would hit a WaitCompletionPacket handle that had reused the same handle value in the meantime, and successfully close that. I don’t know what a WaitCompletionPacket is, but it sounds like it might be related to waiting for keyboard input. At any rate, we probably shouldn’t be closing it unasked.

The attached commit fixes that by invalidating the handle object in closeKey() so that the finalizer knows not to close it again. Unfortunately there seems to be no API for mutating the contents of an N-API “external” value, so I had to box the HKEY in another dynamically managed allocation. Can you think of a more elegant way? I considered using a Buffer or ArrayBuffer instead of an External so that the JS engine would manage the memory, but that would expose the contents to users. The alternative of doing away with either the closeKey function or the finalizer seems unappealing too as it removes functionality.