### PR TITLE
Added DELETE access right required for deleteTree

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,9 @@ export enum Access {
   WOW64_64KEY         = 0x0100,
   WOW64_32KEY         = 0x0200,
 
+  // Standard access rights
+  DELETE              = 0x00010000,
+
   // Generic rights.
   READ              = 0x2_0019,
   WRITE             = 0x2_0006,


### PR DESCRIPTION
According to the page [Registry Key Security and Access Rights](https://docs.microsoft.com/en-us/windows/win32/sysinfo/registry-key-security-and-access-rights), these standard rights are supported: DELETE, READ_CONTROL, WRITE_DAC, and WRITE_OWNER. I'm not sure what the last three are used for, but DELETE is mentioned in [`RegDeleteTree`'s documentation](https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regdeletetreew), so it's pretty essential.