### PR TITLE
Make getValue return null for an unsupported type

### DIFF
--- a/reg.cc
+++ b/reg.cc
@@ -365,7 +365,7 @@ Value getValue(const CallbackInfo& info) {
         NULL,
         &size);
 
-    if (status == ERROR_FILE_NOT_FOUND) {
+    if (status == ERROR_FILE_NOT_FOUND || status == ERROR_UNSUPPORTED_TYPE) {
         return env.Null();
     }
 


### PR DESCRIPTION
I think that's a more helpful behavior for the common case. Say I have a function that reads some configuration. It might look like this:

```typescript
const configNum1 = reg.getValue(hkey, subKey, 'config1', reg.GetValueFlags.RT_REG_DWORD) ?? 123;
const configNum2 = reg.getValue(hkey, subKey, 'config2', reg.GetValueFlags.RT_REG_DWORD) ?? 456;
// ...
```

If an exception occurs, such as no permissions or a corrupted registry, the whole function fails and the user is notified. That's OK. If one value doesn't exist in the registry, a default value is used. But currently, if the value exists but it's of a different type, the function throws an exception. I'd rather treat this case as a value that doesn't exist.